### PR TITLE
Adds dimage

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -27561,7 +27561,7 @@
       "size"
     ],
     "description": "Pure Nim, no external dependencies, image mime type and dimension reader for images",
-    "license": "LGPL-3.0-only",
+    "license": "LGPL-3.0",
     "web": "https://github.com/accodeing/dimage"
   }
 ]

--- a/packages.json
+++ b/packages.json
@@ -27549,5 +27549,19 @@
     "description": "Nim bindings for libmpv",
     "license": "MIT",
     "web": "https://github.com/WeebNetsu/nim-mpv"
+  },
+  {
+    "name": "dimage",
+    "url": "https://github.com/accodeing/dimage",
+    "method": "git",
+    "tags": [
+      "library",
+      "image",
+      "metadata",
+      "size"
+    ],
+    "description": "Pure Nim, no external dependencies, image mime type and dimension reader for images",
+    "license": "LGPL-3.0-only",
+    "web": "https://github.com/accodeing/dimage"
   }
 ]


### PR DESCRIPTION
Adds dimage, a small library that I extracted from a larger project. It allows you to pull mime type and size information from images. It is written in pure Nim and has cligen as its only dependency except for the Nim stdlib.